### PR TITLE
fix for the hud not loading due to incorrect "ui_version" on info.vdf

### DIFF
--- a/info.vdf
+++ b/info.vdf
@@ -1,4 +1,4 @@
-"goog hud"
+"googhud"
 {
-	"ui_version"	"6"
+	"ui_version"	"3"
 }


### PR DESCRIPTION
as said in hypnotize's hud guide: 
> If your HUD already featured the info.vdf but the HUD doesn't work make sure the ui_version is set to the current supported value: 3

this is a small pr, but fixes the hud "not working" according to people, feel free to close this if you want to fix it yourself