### PR TITLE
fixed haarp/Carrier flag icon overlapping with control points + KOTH Timer on match hud 0

### DIFF
--- a/resource/ui/HudObjectiveFlagPanel.res
+++ b/resource/ui/HudObjectiveFlagPanel.res
@@ -1,30 +1,30 @@
 "Resource/UI/HudObjectiveFlagPanel.res"
-{	
+{
 	"ObjectiveStatusFlagPanel"
 	{
 		"ControlName"								"EditablePanel"
 		"fieldName"									"ObjectiveStatusFlagPanel"
-		"xpos"										"0"	
+		"xpos"										"0"
 		"ypos"										"0"
 		"zpos"										"1"
 		"wide"										"f0"
 		"tall"										"480"
 		"visible"									"1"
 		"enabled"									"1"
-		
+
 		"if_hybrid"
 		{
 			"zpos"									"-1"
 		}
 		"if_mvm"
 		{
-			"xpos"									"-7"	
+			"xpos"									"-7"
 			"ypos"									"-8"
 		}
-		
+
 	}
 
-	"BlueScoreBG"	
+	"BlueScoreBG"
 	{
 		"ControlName"								"CExImageButton"
 		"fieldName"									"BlueScoreBG"
@@ -56,7 +56,7 @@
 			"visible"								"0"
 		}
 	}
-	
+
 	"BlueScore"
 	{
 		"ControlName"								"CExLabel"
@@ -68,11 +68,11 @@
 		"tall"										"19"
 		"visible"									"1"
 		"enabled"									"1"
-		"textAlignment"								"west"	
+		"textAlignment"								"west"
 		"labelText"									"%bluescore%"
 		"font"										"GameFont10"
 		"fgcolor"									"White"
-		
+
 		"if_hybrid"
 		{
 			"visible"								"0"
@@ -88,8 +88,8 @@
 			"visible"								"0"
 		}
 	}
-	
-	"RedScoreBG"	
+
+	"RedScoreBG"
 	{
 		"ControlName"								"CExImageButton"
 		"fieldName"									"RedScoreBG"
@@ -121,7 +121,7 @@
 			"visible"								"0"
 		}
 	}
-	
+
 	"RedScore"
 	{
 		"ControlName"								"CExLabel"
@@ -133,11 +133,11 @@
 		"tall"										"19"
 		"visible"									"1"
 		"enabled"									"1"
-		"textAlignment"								"east"	
+		"textAlignment"								"east"
 		"labelText"									"%redscore%"
 		"font"										"GameFont10"
-		"fgcolor"									"White"		
-		
+		"fgcolor"									"White"
+
 		"if_hybrid"
 		{
 			"visible"								"0"
@@ -167,7 +167,7 @@
 		"enabled"									"1"
 		"image"										"../hud/objectives_flagpanel_carried_red"
 		"scaleImage"								"1"
-		
+
 		"if_hybrid"
 		{
 			"ypos"									"r142"
@@ -196,7 +196,7 @@
 		"brighttext"								"0"
 		"font"										"DefaultVerySmall"
 		"fgcolor"									"White"
-		
+
 		"if_hybrid"
 		{
 			"visible"								"0"
@@ -210,36 +210,36 @@
 			"visible"								"0"
 		}
 	}
-		
+
 	"BlueFlag"
 	{
 		"ControlName"								"CTFFlagStatus"
 		"fieldName"									"BlueFlag"
 		"xpos"										"c-74"
-		"ypos"										"r27"	
+		"ypos"										"r27"
 		"zpos"										"5"
 		"wide"										"160"
 		"tall"										"90"
 		"visible"									"1"
 		"enabled"									"1"
-		
+
 		"if_hybrid"
 		{
 			"visible"								"0"
 			"ypos"									"r100"
 		}
-		
+
 		"if_hybrid_single"
 		{
 			"xpos"									"c-55"
-			"ypos"									"r25"
+			"ypos"									"r55"
 		}
-		
+
 		"if_hybrid_double"
 		{
 			"xpos"									"c-115"
 		}
-		
+
 		"if_no_flags"
 		{
 			"visible"								"0"
@@ -250,36 +250,36 @@
 			"visible"								"1"
 		}
 	}
-	
+
 	"RedFlag"
 	{
 		"ControlName"								"CTFFlagStatus"
 		"fieldName"									"RedFlag"
 		"xpos"										"c-35"
-		"ypos"										"r27"	
+		"ypos"										"r27"
 		"zpos"										"5"
 		"wide"										"160"
 		"tall"										"90"
 		"visible"									"1"
 		"enabled"									"1"
-				
+
 		"if_hybrid"
 		{
 			"visible"								"0"
 			"ypos"									"r100"
 		}
-		
+
 		"if_hybrid_single"
 		{
 			"xpos"									"c-55"
 			"ypos"									"r25"
 		}
-		
+
 		"if_hybrid_double"
 		{
 			"xpos"									"c-45"
 		}
-		
+
 		"if_no_flags"
 		{
 			"visible"								"0"
@@ -290,20 +290,20 @@
 			"visible"								"0"
 			"ypos" 									"9999"
 		}
-	}	
-	
+	}
+
 	"CaptureFlag"
 	{
 		"ControlName"								"CTFArrowPanel"
 		"fieldName"									"CaptureFlag"
 		"xpos"										"cs-.5"
-		"ypos"										"r38"	
+		"ypos"										"r38"
 		"zpos"										"5"
 		"wide"										"40"
 		"tall"										"40"
 		"visible"									"0"
 		"enabled"									"1"
-		
+
 		"if_hybrid"
 		{
 			"ypos"									"r100"
@@ -314,7 +314,7 @@
 			"visible"								"0"
 		}
 	}
-	
+
 	"PoisonIcon"
 	{
 		"ControlName"								"ImagePanel"
@@ -341,12 +341,12 @@
 		"tall"										"20"
 		"visible"									"0"
 		"enabled"									"1"
-		"textAlignment"								"center"	
+		"textAlignment"								"center"
 		"labelText"									"%redscore%"
 		"font"										"HudFontMediumBold"
 		"fgcolor"									"White"
-	}	
-	
+	}
+
 	"SpecCarriedImage"
 	{
 		"ControlName"								"ImagePanel"
@@ -362,10 +362,10 @@
 		"scaleImage"								"1"
 	}
 
-	
-	
-	
-	
+
+
+
+
 	"OutlineBG"
 	{
 		"ControlName"	"ImagePanel"

--- a/resource/ui/hudobjectivekothtimepanel.res
+++ b/resource/ui/hudobjectivekothtimepanel.res
@@ -1,5 +1,5 @@
 "Resource/UI/HudObjectiveKothTimePanel.res"
-{	
+{
 	"HudKothTimeStatus"
 	{
 		if_match
@@ -55,7 +55,7 @@
 	{
 		"ControlName"		"CTFHudTimeStatus"
 		"fieldName"			"BlueTimer"
-		"xpos"				"0"
+		"xpos"				"c-67"
 		"ypos"				"0"
 		"zpos"				"2"
 		"wide"				"66"
@@ -83,15 +83,15 @@
 			"delta_lifetime"		"1.5"
 			"delta_item_font"		"GameFont16"
 		}
-		
+
 		"TimePanelValue"
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"		"TimePanelValue"
 			"font"			"GameFont16"
 			"fgcolor"		"white"
-			"xpos"			"23"
-			"ypos"			"0"
+			"xpos"			"25"
+			"ypos"			"-5"
 			"zpos"			"3"
 			"wide"			"50"
 			"tall"			"31"
@@ -109,9 +109,9 @@
 				"wide"			"50"
 				"tall"			"31"
 				"font"			"GameFont16"
-			
+
 			}
-		}	
+		}
 	}
 
 	"RedTimer"
@@ -146,15 +146,15 @@
 			"delta_lifetime"		"1.5"
 			"delta_item_font"		"GameFont16"
 		}
-		
+
 		"TimePanelValue"
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"		"TimePanelValue"
 			"font"			"GameFont16"
 			"fgcolor"		"white"
-			"xpos"			"23"
-			"ypos"			"0"
+			"xpos"			"27"
+			"ypos"			"-5"
 			"zpos"			"3"
 			"wide"			"45"
 			"tall"			"31"
@@ -172,11 +172,11 @@
 				"wide"			"50"
 				"tall"			"31"
 				"font"			"GameFont16"
-			
+
 			}
-		}	
+		}
 	}
-	
+
 	"ActiveTimerBG"
 	{
 		"ControlName"		"ImagePanel"
@@ -188,9 +188,9 @@
 		"tall"				"0"
 		"visible"			"0"
 		"enabled"			"1"
-		"image"				""	
+		"image"				""
 		"fillcolor"			"white"
-		"scaleImage"		"0"	
+		"scaleImage"		"0"
 	}
 //	"Shade"
 //	{


### PR DESCRIPTION
tldr: 
- `resource/ui/hudobjectiveflagpanel.res` -> changed ypos of `if_hybrid_single` in `BlueFlag` from r25 to r55
- `resource/ui/hudobjectivekothtimepanel.res` -> moved `BlueTimer` xpos to c-67, moved both `TimePanelValue` fields to ypos -5 + a bit to the right to center them on background 

before
![image](https://github.com/GreySux/googhud/assets/41777800/cbac6c60-2a82-4426-8c8d-c1fccad994af)

after
![image](https://github.com/GreySux/googhud/assets/41777800/60f863c6-2146-4779-b578-cd29366378ed)

koth fix for match hud 0 (best that can be done, atleast the timers are aligned)
![image](https://github.com/GreySux/googhud/assets/41777800/456f50d8-bd7f-4b62-aeec-e5d2919a3c87)


might also try to implement uber icons today or tomorrow (hardest part of this is finding someone who plays medic in a pub)

i will also see if i can somehow tidy up the koth timers, i'm posting this now just before i go to sleep and trying to fix this gave me a headache so thats the best i can do