### PR TITLE
Fixed the Mann vs. Machine mission selection dialog sometimes drawing under the category controls

### DIFF
--- a/resource/ui/MatchMakingDashBoardMvMCriteria.res
+++ b/resource/ui/MatchMakingDashBoardMvMCriteria.res
@@ -7,7 +7,7 @@
 		"fieldName"		"MVMCriteria"
 		"xpos"			"r0"
 		"ypos"			"10"
-		"zpos"			"1002"
+		"zpos"			"1003"
 		"wide"			"420"
 		"tall"			"f70"
 		"visible"		"1"


### PR DESCRIPTION
Source: https://github.com/SteamDatabase/GameTracking-TF2/commit/80f018ba3269ab3b9dad70e38bf1421ec124c62c#diff-5afba1f95a68152b042b5e9ccbc7be5eb853434238588500e4cf4e882dfbba41